### PR TITLE
Fix horizontal overflow bug on search bar

### DIFF
--- a/components/site-search/style.css
+++ b/components/site-search/style.css
@@ -25,7 +25,6 @@
 .site-search input {
     display:block;
     height:2em;
-    flex-basis:auto;
     padding:0.5em;
     width: 100%;
     font-size:0.85em;

--- a/components/site-search/style.css
+++ b/components/site-search/style.css
@@ -25,11 +25,16 @@
 .site-search input {
     display:block;
     height:2em;
-    flex:1;
+    flex-basis:auto;
     padding:0.5em;
-    width:0;
+    width: 100%;
     font-size:0.85em;
     border:0;
     outline:0;
     background:transparent;
+    color: transparent;
+}
+
+.site-search.large input {
+    color: initial;
 }


### PR DESCRIPTION
Make search bar behavior consistent on Firefox

Rudimentary fix for #3. The new behavior on Firefox will appear like so:

![markonavfixed](https://cloud.githubusercontent.com/assets/8265238/23582127/53222602-00d8-11e7-9ec8-2255e51f9baf.gif)

while the search bar on Chrome will continue behaving as before:

![markonavchrome](https://cloud.githubusercontent.com/assets/8265238/23582131/7e276f74-00d8-11e7-9230-fe3e4af5f48a.gif)