### PR TITLE
adjust home-header styling

### DIFF
--- a/routes/index/components/home-hero/index.marko
+++ b/routes/index/components/home-hero/index.marko
@@ -19,7 +19,7 @@ style {
     .home-header {
         background-color:#fff;
         width:100%;
-        padding:3em 2em;
+        padding:2.5em 2em;
         justify-content:center;
         align-items:flex-start;
         flex-direction:row;
@@ -32,24 +32,22 @@ style {
     .home-header h1 {
         font-size:2em;
         font-weight:300;
-        margin:0;
+        margin:0.5em 0 0.6em;
         padding:0;
         border:0;
         color:#46484a;
-        margin-bottom:0.5em;
         max-width:17em;
     }
 
     .home-header img.logo {
-        height:8em;
-        width:14.6em;
+        height:9em;
+        width:16.425em;
         margin-right:2em;
         margin-top:1.5em;
     }
 
     .home-header img.logo-text {
-        height:4.8em;
-        margin-bottom:0.2em;
+        height:5em;
     }
 
     .home-header .actions {
@@ -92,7 +90,6 @@ style {
         }
         .home-header h1 {
             text-align:center;
-            margin-top:0.5em;
         }
         .home-header img.logo {
             margin:0;


### PR DESCRIPTION
This makes the following changes to home-header:
- more vertical margin on the tagline
- slightly larger logo for approximate alignment with text
- less vertical padding on the container

I know this is pretty subjective, completely up to you if you'd like to take changes like these.

Before:
![screen shot 2017-03-05 at 11 13 13 am](https://cloud.githubusercontent.com/assets/3595986/23590434/c17b4086-0194-11e7-9a68-d5283b2e9ee5.png)

After:
![screen shot 2017-03-05 at 11 13 07 am](https://cloud.githubusercontent.com/assets/3595986/23590437/c609d3f6-0194-11e7-9c7e-4e5d7d02341a.png)

