### PR TITLE
add missing events-light package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "babel-preset-es2015": "^6.22.0",
     "codemirror": "^5.23.0",
     "codemirror-atom-modes": "^1.0.1",
+    "events-light": "^1.0.5",
     "gh-got": "^5.0.0",
     "headspace": "^0.1.1",
     "highlights": "^1.4.1",


### PR DESCRIPTION
I saw this package was missing `events-light` so I installed it and added to `package.json`

Without that module it could not `npm start`

👍 ?