### PR TITLE
Close mobile menu when clicking on doc-sidebar

### DIFF
--- a/components/doc-sidebar/component-browser.js
+++ b/components/doc-sidebar/component-browser.js
@@ -64,6 +64,7 @@ module.exports = {
                 header.hide();
                 header.pause();
                 header.resume();
+                this.hide();
             });
         });
 


### PR DESCRIPTION
Address #18.

When clicking on a hash anchor tag, the mobile menu would not close.
This PR addresses that issue.