### PR TITLE
Aligning 'Choose a syntax' part arrows

### DIFF
--- a/routes/index/components/home-syntax/index.marko
+++ b/routes/index/components/home-syntax/index.marko
@@ -78,6 +78,10 @@ style {
         height: 1.2em;
         text-align: center;
         border-radius: 50%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        padding-bottom: .24em;
     }
 
     @media (max-width:55em) {


### PR DESCRIPTION
They are not in the center of circle.