### PR TITLE
Add a meta description

### DIFF
--- a/components/site-layout/index.marko
+++ b/components/site-layout/index.marko
@@ -4,6 +4,7 @@
     <title>${data.title ? data.title + ' | Marko' : 'Marko'}</title>
     <link rel="icon" type="image/png" sizes="32x32" href="./favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="Description" content="Marko is a friendly (and fast!) UI library that makes building web apps fun." />
     <script>
         var scalingBodyFont = false;
 


### PR DESCRIPTION
Fixes the issue:
Document does not have a meta description
Meta descriptions may be included in search results to concisely summarize page content.
https://developers.google.com/web/tools/lighthouse/audits/description