### PR TITLE
Update markdown.js

### DIFF
--- a/routes/docs/util/markdown.js
+++ b/routes/docs/util/markdown.js
@@ -83,7 +83,7 @@ exports.toTemplate = function renderMarkdown(markdownDocument) {
     .replace(/\&/g, "&amp;")
     .replace(/\$/g, "&#36;")
     .replace(/https?:\/\/markojs\.com\//g, "/")
-    .replace(/\.\/([\w\d-\/]+)\.md/g, match => {
+    .replace(/([\w\d\-\/]+)\.md/g, match => {
       // Markdown documents from external sources do not have a file path
       if (filePath) {
         const linkpath = path.resolve(path.dirname(filePath), match);


### PR DESCRIPTION
Fixed regex for replacing markdown links, since they currently will return 404. Example: http://markojs.com/docs/server-side-rendering/ (Links to server side rendring frameworks)

Description
Changed regex to one that properly detects the markdown files

Checklist:
[ x ] I have read the CONTRIBUTING document and have signed (or will sign) the CLA.
[ x ] I have updated/added documentation affected by my changes.
[ x ] I have added tests to cover my changes.