### PR TITLE
Add a [lang] attribute on the <html> element

### DIFF
--- a/components/site-layout/index.marko
+++ b/components/site-layout/index.marko
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <title>${data.title ? data.title + ' | Marko' : 'Marko'}</title>
     <link rel="icon" type="image/png" sizes="32x32" href="./favicon.png" />


### PR DESCRIPTION
Fixes the issue: Page Specifies Valid Language.
If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly.
Learn more: https://dequeuniversity.com/rules/axe/2.2/html-lang-valid